### PR TITLE
Fix double-add issue

### DIFF
--- a/AuthMatrix.py
+++ b/AuthMatrix.py
@@ -142,11 +142,9 @@ class BurpExtender(IBurpExtender, ITab, IMessageEditorController, IContextMenuFa
         def addPopup(component, popup):
             class genericMouseListener(MouseAdapter):
                 def mousePressed(self, e):
-                    print("mousePressed")
                     if e.isPopupTrigger():
                         self.showMenu(e)
                 def mouseReleased(self, e):
-                    print("mouseReleased")
                     if e.isPopupTrigger():
                         self.showMenu(e)
                 def showMenu(self, e):
@@ -583,7 +581,7 @@ class BurpExtender(IBurpExtender, ITab, IMessageEditorController, IContextMenuFa
                             regex = "^"+re.escape(responseCodeHeader)
                     # Must create a new RequestResponseStored object since modifying the original messageInfo
                     # from its source (such as Repeater) changes this saved object. MessageInfo is a reference, not a copy
-                    messageIndex = self.extender._db.createNewMessage(RequestResponseStored(self,requestResponse=messageInfo), name, regex)
+                    messageIndex = self.extender._db.createNewMessage(RequestResponseStored(self.extender,requestResponse=messageInfo), name, regex)
                 self.extender._messageTable.redrawTable()
                 self.extender._chainTable.redrawTable()
                 self.extender.highlightTab()
@@ -595,7 +593,6 @@ class BurpExtender(IBurpExtender, ITab, IMessageEditorController, IContextMenuFa
                 self.extender = extender
 
             def actionPerformed(self, e):
-                print('UserCookiesActionListener.actionPerformed')
                 for messageInfo in messages:
                     cookieVal = ""
                     requestInfo = self.extender._helpers.analyzeRequest(messageInfo)


### PR DESCRIPTION
__Issue__: In the recent versions of Burp Suite Pro, when adding requests to AuthMatrix from other tools (Proxy, Repeater), all the requests are added twice, as shown in the screenshots below. 

![2023-08-29_12-55](https://github.com/PortSwigger/auth-matrix/assets/96278236/fa2de75b-f2e3-4674-8a1c-b993e9e3e86a)
![2023-08-29_12-56](https://github.com/PortSwigger/auth-matrix/assets/96278236/a7b0aabd-fa5d-447f-b6bd-207764a751f5)

It was discovered that when the "Send request(s) to AuthMatrix" menu item is clicked on, the [addRequestsToTab](https://github.com/PortSwigger/auth-matrix/blob/ae73ab41ecd49bde6e4d2d4fd75b9c6da34002d1/AuthMatrix.py#L567C17-L567C17) function is called twice. This is probably caused by how underlying components (Burp or Jython) handles adding a 
function (instead of a `ActionListener` instance) as the argument to [`addActionListener`](https://github.com/PortSwigger/auth-matrix/blob/ae73ab41ecd49bde6e4d2d4fd75b9c6da34002d1/AuthMatrix.py#L626).